### PR TITLE
Switch to ignorePackages for import/extensions

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -414,7 +414,7 @@ export default [
       "import/no-named-as-default-member": "warn",
 
       // Style guide
-      "import/extensions": ["error", "always", { "ts": "never", "tsx": "never" }],
+      "import/extensions": ["error", "ignorePackages", { "ts": "never", "tsx": "never" }],
       "import/no-duplicates": "warn",
 
       // JSDoc rules


### PR DESCRIPTION
This fixes the case where this code;

```ts
import { version as pcuiVersion, revision as pcuiRevision } from '@playcanvas/pcui/react';
```

...generates this error:

```bash
C:\dev\model-viewer\src\index.tsx
  2:66  error  Missing file extension "mjs" for "@playcanvas/pcui/react"  import/extensions
```

