### PR TITLE
Add `@visibleif` and `@enabledif` jsdoct tags

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,7 +13,9 @@ const esmScriptTags = [
   'precision',
   'size',
   'step',
-  'title'
+  'title',
+  'visibleif',
+  'enabledif'
 ]
 
 export default [


### PR DESCRIPTION
Adds new conditional `@visibleif` and `@enabledif` tags as per https://github.com/playcanvas/editor/issues/1196 and https://github.com/playcanvas/attribute-parser/pull/32