### PR TITLE
Document v3 subpath exports; allow prerelease bump in release.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,46 @@ ESLint configuration developed by the PlayCanvas team and leveraged by many Play
 npm install -D @playcanvas/eslint-config eslint
 ```
 
-2. Create an `eslint.config.js` file in your project root:
+2. Create an `eslint.config.js` file in your project root. Import the config for your project type from its subpath — this loads only that config's plugins:
+
+```js
+// TypeScript projects (modern, strict rules)
+import typescriptConfig from '@playcanvas/eslint-config/typescript';
+
+export default [
+    ...typescriptConfig
+    // Your custom configurations here
+];
+```
+
+The available entry points are:
+
+- `@playcanvas/eslint-config/typescript` — modern, strict rules for TypeScript (ESM) projects
+- `@playcanvas/eslint-config/javascript` (alias: `/legacy`) — rules for JavaScript + JSDoc (ESM) projects, such as the PlayCanvas engine
+- `@playcanvas/eslint-config/react` — React rules, layered on top of one of the above
+
+For example, a React + TypeScript project:
+
+```js
+import reactConfig from '@playcanvas/eslint-config/react';
+import typescriptConfig from '@playcanvas/eslint-config/typescript';
+
+export default [
+    ...typescriptConfig,
+    ...reactConfig
+    // Your custom configurations here
+];
+```
+
+Alternatively, the default export exposes every config as an object:
 
 ```js
 import playcanvasConfig from '@playcanvas/eslint-config';
 
 export default [
     ...playcanvasConfig.typescript
-    // ...playcanvasConfig.react, // Uncomment if using react
-    // ...playcanvasConfig.legacy, // Uncomment if using legacy javascript rules
-    // Your custom configurations here
+    // ...playcanvasConfig.legacy, // JavaScript + JSDoc rules
+    // ...playcanvasConfig.react // React rules
 ];
 ```
 

--- a/release.sh
+++ b/release.sh
@@ -3,8 +3,8 @@
 TYPE=$1
 PRE_ID_PREVIEW="beta"
 
-if [[ ! " major minor patch premajor " =~ " $TYPE " ]]; then
-    echo "Usage: $0 (major|minor|patch|premajor)"
+if [[ ! " major minor patch premajor prerelease " =~ " $TYPE " ]]; then
+    echo "Usage: $0 (major|minor|patch|premajor|prerelease)"
     exit 1
 fi
 


### PR DESCRIPTION
Small follow-up to #38.

## Changes

**README — document the subpath exports**
#38 added subpath entry points (`/typescript`, `/legacy`, `/javascript`, `/react`) but the usage docs still only showed the default-object import. This updates the Usage section to:
- Recommend importing from a subpath (e.g. `@playcanvas/eslint-config/typescript`), which loads only that config's plugins instead of all of them.
- List the entry points: `/typescript` (modern, strict, TS+ESM), `/javascript` (alias `/legacy`, for JS+JSDoc ESM projects like the engine), `/react` (overlay).
- Show a React + TypeScript example.
- Keep the default-object export (`playcanvasConfig.typescript`, etc.) documented as an alternative.

**release.sh — allow `prerelease` bumps**
`release.sh` only accepted `major|minor|patch|premajor`, so there was no way to cut `3.0.0-beta.0` → `3.0.0-beta.1` — which is exactly the bump needed to publish the packaging fix from #38. Adds `prerelease` to the allowed bump types.

## Verification
- `npm run lint` → 0 (README is Prettier-clean)
- `bash -n release.sh` → syntax OK; `./release.sh prerelease` now permitted
