### PR TITLE
Pin PlayCanvas house-style Prettier options in the typescript config

### DIFF
--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -13,6 +13,16 @@ const ignoreConfig = {
 const baseConfig = {
     rules: {
         curly: 'error',
+        // pin the PlayCanvas house style so consumers get it without their own prettier config
+        'prettier/prettier': [
+            'error',
+            {
+                tabWidth: 4,
+                singleQuote: true,
+                printWidth: 120,
+                trailingComma: 'none'
+            }
+        ],
         'import/order': [
             'error',
             {


### PR DESCRIPTION
## Summary

The `.typescript` tier runs Prettier through `eslint-plugin-prettier`, but the `prettier/prettier` rule formatted using whatever Prettier config the *consumer* had — or **Prettier's defaults** (2-space, double quotes, `trailingComma: 'all'`) when a consumer has none (e.g. `editor`). That means a consumer with no `prettier.config` would have ESLint enforce a style that isn't the PlayCanvas house style.

This pins the house style directly on the rule:

```js
'prettier/prettier': ['error', { tabWidth: 4, singleQuote: true, printWidth: 120, trailingComma: 'none' }]
```

(values identical to this repo's `prettier.config.mjs`).

## Behaviour to be aware of

- **Overrides `.prettierrc`.** Per [eslint-plugin-prettier docs](https://github.com/prettier/eslint-plugin-prettier#options), inline rule options *"merge and override any config set with `.prettierrc` files"*. So for these four keys, the shared config now wins even over a consumer's own Prettier config. That's intentional — it guarantees the house style for every `/typescript` consumer.
- **Editors/Prettier-CLI don't see these options.** The Prettier VS Code extension and the `prettier` CLI read `.prettierrc`, not ESLint settings. So for format-on-save parity, a consumer should still keep a matching `.prettierrc`; otherwise format-on-save (defaults) can disagree with `eslint`. A possible follow-up is to export a **shareable Prettier config** (e.g. `@playcanvas/eslint-config/prettier`) so both tools share one source of truth.
- **Slight divergence from vscode-extension.** That repo leaves Prettier options to its local `prettier.config.mjs`, so its resolved `prettier/prettier` rule has no inline options. The rest of the TS rule set remains identical.
- **Only the `.typescript` tier.** `legacy`/`react` don't run Prettier, so they're unaffected.

## Verification

- `eslint --print-config` resolves `prettier/prettier` to `[2, { tabWidth: 4, singleQuote: true, printWidth: 120, trailingComma: 'none' }]`
- `npm run lint` → 0 (the repo's own `prettier.config.mjs` matches these values, so dogfooding stays green)

## Rollout

Reaches consumers only via a new beta — fold into the next `3.0.0-beta.2` publish.
