### PR TITLE
Switch to the recommended Prettier integration (separate + eslint-config-prettier)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,22 @@ export default [
 ];
 ```
 
+3. Prettier is run as a separate step, not through ESLint — the config above only disables the ESLint formatting rules that would conflict with Prettier. To apply the PlayCanvas house style, create a `prettier.config.mjs` that re-exports the shared config:
+
+```js
+export { default } from '@playcanvas/eslint-config/prettier';
+```
+
+Then run both, for example:
+
+```json
+{
+    "scripts": {
+        "lint": "prettier --check . && eslint ."
+    }
+}
+```
+
 ## Features
 
 > [!WARNING]

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
                 "eslint-plugin-jsdoc": "^61.1.11",
                 "eslint-plugin-jsx-a11y": "^6.10.2",
                 "eslint-plugin-package-json": "^0.59.1",
-                "eslint-plugin-prettier": "^5.5.4",
                 "eslint-plugin-react": "^7.37.5",
                 "eslint-plugin-react-hooks": "^7.0.1",
                 "eslint-plugin-regexp": "^2.10.0",
@@ -27,6 +26,7 @@
             "devDependencies": {
                 "@types/eslint-plugin-jsx-a11y": "^6.10.1",
                 "eslint": "^9.39.0",
+                "prettier": "^3.6.2",
                 "publint": "^0.3.15",
                 "typescript": "^5.9.3"
             },
@@ -617,18 +617,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/@pkgr/core": {
-            "version": "0.2.9",
-            "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
-            "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
-            "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/pkgr"
             }
         },
         "node_modules/@publint/pack": {
@@ -2446,36 +2434,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/eslint-plugin-prettier": {
-            "version": "5.5.4",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.4.tgz",
-            "integrity": "sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==",
-            "license": "MIT",
-            "dependencies": {
-                "prettier-linter-helpers": "^1.0.0",
-                "synckit": "^0.11.7"
-            },
-            "engines": {
-                "node": "^14.18.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint-plugin-prettier"
-            },
-            "peerDependencies": {
-                "@types/eslint": ">=8.0.0",
-                "eslint": ">=8.0.0",
-                "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
-                "prettier": ">=3.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/eslint": {
-                    "optional": true
-                },
-                "eslint-config-prettier": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/eslint-plugin-react": {
             "version": "7.37.5",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
@@ -2666,12 +2624,6 @@
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "license": "MIT"
-        },
-        "node_modules/fast-diff": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-            "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-            "license": "Apache-2.0"
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
@@ -4272,8 +4224,8 @@
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
             "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -4282,18 +4234,6 @@
             },
             "funding": {
                 "url": "https://github.com/prettier/prettier?sponsor=1"
-            }
-        },
-        "node_modules/prettier-linter-helpers": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-            "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-            "license": "MIT",
-            "dependencies": {
-                "fast-diff": "^1.1.2"
-            },
-            "engines": {
-                "node": ">=6.0.0"
             }
         },
         "node_modules/prop-types": {
@@ -5032,21 +4972,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/synckit": {
-            "version": "0.11.11",
-            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
-            "integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
-            "license": "MIT",
-            "dependencies": {
-                "@pkgr/core": "^0.2.9"
-            },
-            "engines": {
-                "node": "^14.18.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/synckit"
             }
         },
         "node_modules/tinyglobby": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         ".": "./dist/index.js",
         "./javascript": "./dist/configs/legacy.js",
         "./legacy": "./dist/configs/legacy.js",
+        "./prettier": "./dist/configs/prettier.js",
         "./react": "./dist/configs/react.js",
         "./typescript": "./dist/configs/typescript.js"
     },
@@ -45,7 +46,6 @@
         "eslint-plugin-jsdoc": "^61.1.11",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-package-json": "^0.59.1",
-        "eslint-plugin-prettier": "^5.5.4",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-regexp": "^2.10.0",
@@ -56,6 +56,7 @@
     "devDependencies": {
         "@types/eslint-plugin-jsx-a11y": "^6.10.1",
         "eslint": "^9.39.0",
+        "prettier": "^3.6.2",
         "publint": "^0.3.15",
         "typescript": "^5.9.3"
     },

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,11 +1,2 @@
-/** @import { Config } from 'prettier' */
-
-/**
- * @type {Config}
- */
-export default {
-    tabWidth: 4,
-    singleQuote: true,
-    printWidth: 120,
-    trailingComma: 'none'
-};
+// re-export the shared PlayCanvas Prettier config (single source of the house style)
+export { default } from './dist/configs/prettier.js';

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -26,7 +26,7 @@ writeFileSync(
 // install ONLY the peers + the packed tarball — never the config's devDependencies
 run(`npm install --no-audit --no-fund --no-save eslint@9 typescript@5 "${join(dir, tarball)}"`, dir);
 
-const entries = ['', '/typescript', '/legacy', '/javascript', '/react'];
+const entries = ['', '/typescript', '/legacy', '/javascript', '/react', '/prettier'];
 for (const entry of entries) {
     const spec = `@playcanvas/eslint-config${entry}`;
     run(`node --input-type=module -e "await import('${spec}'); console.log('  loaded ${spec}')"`, dir);

--- a/src/configs/prettier.ts
+++ b/src/configs/prettier.ts
@@ -1,0 +1,8 @@
+// shared PlayCanvas Prettier config — the single source of the house style.
+// consume from a prettier.config.mjs: export { default } from '@playcanvas/eslint-config/prettier'
+export default {
+    tabWidth: 4,
+    singleQuote: true,
+    printWidth: 120,
+    trailingComma: 'none'
+};

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -1,7 +1,7 @@
 import eslint from '@eslint/js';
+import eslintConfigPrettier from 'eslint-config-prettier/flat';
 import pluginImport from 'eslint-plugin-import';
 import * as pluginPackageJson from 'eslint-plugin-package-json';
-import pluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
 import globals from 'globals';
 import jsoncEslintParser from 'jsonc-eslint-parser';
 import tseslint from 'typescript-eslint';
@@ -73,10 +73,12 @@ export default [
     ...tseslint.configs.recommended,
     ...tseslint.configs.strict,
     ...tseslint.configs.stylistic,
-    pluginPrettierRecommended,
     pluginImport.flatConfigs.recommended,
     ignoreConfig,
     baseConfig,
     tsFilesConfig,
-    packageJsonConfig
+    packageJsonConfig,
+    // last: turn off ESLint formatting rules that would conflict with Prettier
+    // (run Prettier itself separately — see the prettier export / README)
+    eslintConfigPrettier
 ];


### PR DESCRIPTION
Replaces #45. Switches the Prettier integration to the approach recommended by the Prettier, ESLint and typescript-eslint teams: **run Prettier separately, and use `eslint-config-prettier` only to disable conflicting ESLint rules** — instead of running Prettier *through* ESLint via `eslint-plugin-prettier`.

## Why

- The Prettier / ESLint / typescript-eslint docs recommend against `eslint-plugin-prettier` (performance, and conflating formatting with linting).
- This repo already runs `prettier --check .` as a separate step in `lint`, so Prettier was effectively running **twice** (once standalone, once inside ESLint).

## Changes

- **Drop `eslint-plugin-prettier`**; add `eslint-config-prettier/flat` as the **last** entry of the `typescript` config so it disables every conflicting ESLint formatting rule.
- **New shareable Prettier config**: `@playcanvas/eslint-config/prettier` (`src/configs/prettier.ts`) — a single source for the house style (`tabWidth: 4`, `singleQuote: true`, `printWidth: 120`, `trailingComma: 'none'`) that the **editor, the `prettier` CLI, and CI** all read, so they can't disagree.
- **Dogfood**: this repo's `prettier.config.mjs` now re-exports the shared config.
- **Add `prettier` as a devDependency** (it was previously only transitive via `eslint-plugin-prettier`).
- **README** documents the recommended setup.

Consumer usage:

```js
// eslint.config.js  (unchanged)
import typescriptConfig from '@playcanvas/eslint-config/typescript';
export default [...typescriptConfig];

// prettier.config.mjs  (new — gets the house style)
export { default } from '@playcanvas/eslint-config/prettier';

// package.json
"scripts": { "lint": "prettier --check . && eslint ." }
```

## Effect on the rule set

`prettier/prettier` is removed from the resolved `typescript` config (478 vs 481 rules — the 3 are `prettier/prettier` plus `arrow-body-style`/`prefer-arrow-callback`, which the plugin's preset turned off and which remain off). All conflicting formatting rules (`indent`, `quotes`, `semi`, `comma-dangle`, …) stay disabled via `eslint-config-prettier`.

This **diverges from `vscode-extension`** (still on `eslint-plugin-prettier`) until that repo is updated to match.

## Verification

- `npm run lint` → 0
- `npm test` (clean-room) → loads `.`, `/typescript`, `/legacy`, `/javascript`, `/react`, **`/prettier`**
- `npm run publint` → "All good!"
- `eslint --print-config`: `prettier/prettier` absent; `eslint-config-prettier` disables conflicting rules

## Rollout

Reaches consumers via the next **`3.0.0-beta.2`**.
