### PR TITLE
Ship types for the /prettier export (fixes ts7016 in TS consumers)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,6 @@
 // dogfood the published modern-strict config rather than duplicating it
 import config from './dist/index.js';
 
-export default config.typescript;
+// don't lint the hand-written declaration in types/ — prettier already formats it,
+// and @typescript-eslint rules can crash on ambient .d.ts
+export default [...config.typescript, { ignores: ['types/**'] }];

--- a/package.json
+++ b/package.json
@@ -22,12 +22,16 @@
         ".": "./dist/index.js",
         "./javascript": "./dist/configs/legacy.js",
         "./legacy": "./dist/configs/legacy.js",
-        "./prettier": "./dist/configs/prettier.js",
+        "./prettier": {
+            "types": "./types/prettier.d.ts",
+            "default": "./dist/configs/prettier.js"
+        },
         "./react": "./dist/configs/react.js",
         "./typescript": "./dist/configs/typescript.js"
     },
     "files": [
-        "dist"
+        "dist",
+        "types"
     ],
     "scripts": {
         "build": "npm run clean && tsc",

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -78,6 +78,7 @@ export default [
     baseConfig,
     tsFilesConfig,
     packageJsonConfig,
+
     // last: turn off ESLint formatting rules that would conflict with Prettier
     // (run Prettier itself separately — see the prettier export / README)
     eslintConfigPrettier

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -175,7 +175,7 @@
         // "verbatimModuleSyntax": false
     },
     /** Specify an array of filenames or patterns that should be excluded from the program. (Original: out, plugin) */
-    "exclude": ["dist"]
+    "exclude": ["dist", "types"]
 
     // --- Project References and Includes ---
     /** Specify an array of filenames or patterns that should be included in the program. */

--- a/types/prettier.d.ts
+++ b/types/prettier.d.ts
@@ -1,0 +1,12 @@
+// types for the shared Prettier config (@playcanvas/eslint-config/prettier).
+// hand-written and kept in sync with src/configs/prettier.ts — the eslint configs
+// can't emit declarations (typescript-eslint composed types aren't portable), so
+// only this simple config ships types.
+declare const config: {
+    tabWidth: number;
+    singleQuote: boolean;
+    printWidth: number;
+    trailingComma: 'none';
+};
+
+export default config;


### PR DESCRIPTION
## Summary

TS consumers of `@playcanvas/eslint-config/prettier` — e.g. a typed `prettier.config.mjs` like vscode-extension's (playcanvas/vscode-extension#304) — hit:

```
ts(7016): Could not find a declaration file for module '@playcanvas/eslint-config/prettier'
```

because the package shipped no type declarations. This ships types for the `/prettier` export.

## Changes

- **`types/prettier.d.ts`** (new, hand-written) and the export becomes:
  ```jsonc
  "./prettier": { "types": "./types/prettier.d.ts", "default": "./dist/configs/prettier.js" }
  ```
  Hand-written (not tsc-emitted) because the **eslint** configs can't emit portable declarations — `typescript-eslint`'s composed flat-config types trip `TS2742` ("inferred type cannot be named"). The Prettier config is a simple object, so a small declaration covers it. This is why only `/prettier` ships types for now.
- **`package.json`** — `files` now includes `types`.
- **`tsconfig.json`** — `exclude` adds `types` (the hand-written `.d.ts` isn't a tsc input).
- **`eslint.config.mjs`** (repo's own) — ignores `types/`: `@typescript-eslint/unified-signatures` crashes on the ambient `.d.ts` (`TypeError: typeParameters.params is not iterable`), and Prettier already formats it. Shared config unchanged.
- **`src/configs/typescript.ts`** — blank line above the `eslint-config-prettier` comment (readability; matches vscode-extension).

## Verification (clean-room A/B)

```
WITH the shipped .d.ts:   tsc --strict on `import config from '@playcanvas/eslint-config/prettier'` → exit 0 ✓
WITHOUT it (control):     → error TS7016 (reproduces the bug)
```
Plus `npm run lint` / `npm test` / `npm run publint` all green.

## Rollout

Ships in **`3.0.0-beta.3`**. After publish, vscode-extension's `prettier.config.mjs` squiggle clears once it bumps to beta.3 (no code change needed there).

## Known limitation

The `/typescript`, `/legacy`, `/react` exports still ship no types (same `TS2742` blocker). A consumer importing those in a type-checked context could see `ts(7016)`; flat eslint configs are usually `.mjs` excluded from `tsc`, so this is rarely hit. Typing those would need explicit annotations on the config arrays — out of scope here.
