### PR TITLE
Lint .tsx (and cjs/mts/cts) under /typescript

### DIFF
--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -51,7 +51,7 @@ const baseConfig = {
 };
 
 const tsFilesConfig = {
-    files: ['**/*.{js,mjs,ts}'],
+    files: ['**/*.{js,mjs,cjs,ts,tsx,mts,cts}'],
     plugins: {
         '@typescript-eslint': tseslint.plugin
     },


### PR DESCRIPTION
Follow-up to the v3 rollout (#48). Migrating React + TS repos (model-viewer #381, and pcui) surfaced that the `/typescript` tier's `tsFilesConfig` only matched `**/*.{js,mjs,ts}` — so **`.tsx` files weren't routed through the typescript-eslint parser** and failed to parse / went unlinted. (model-viewer needed a hand-added `.tsx` parser override as a stopgap.)

## Fix
Broaden the glob to `**/*.{js,mjs,cjs,ts,tsx,mts,cts}`. The typescript-eslint parser enables JSX automatically for `.tsx` and keeps it **off** for `.ts` (preserving `<T>x` type assertions) — so a single block handles all extensions correctly.

## Validation
- Build + `prettier --check` + self-lint (dogfoods `/typescript`): green.
- `.tsx` with JSX now parses (verified via stdin); `.ts` type assertions still parse (JSX stays off). No regression.

Once released, the React consumer PRs can drop their `.tsx` parser stopgaps.