### PR TITLE
fix: enforce object curly spacing

### DIFF
--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -79,6 +79,12 @@ const packageJsonConfig = {
     rules: pluginPackageJson.configs.recommended.rules
 };
 
+const spacingConfig = {
+    rules: {
+        'object-curly-spacing': ['error', 'always']
+    }
+};
+
 export default [
     eslint.configs.recommended,
     ...tseslint.configs.recommended,
@@ -90,7 +96,8 @@ export default [
     tsFilesConfig,
     packageJsonConfig,
 
-    // last: turn off ESLint formatting rules that would conflict with Prettier
+    // turn off ESLint formatting rules that would conflict with Prettier
     // (run Prettier itself separately — see the prettier export / README)
-    eslintConfigPrettier
+    eslintConfigPrettier,
+    spacingConfig
 ];


### PR DESCRIPTION
## Summary
- Re-enable object curly spacing enforcement after the Prettier compatibility config.
- Ensure compact named imports like `import type {Stats}` are reported by the TypeScript config.

## Manual smoke test
1. Open a TypeScript consumer project using `@playcanvas/eslint-config/typescript`.
2. Add `import type {Stats} from 'node:fs';` to a TypeScript file.
3. Observe the editor ESLint diagnostic for missing spaces inside the import braces.