### PR TITLE
chore: disable prefer-for-of rule

### DIFF
--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -64,7 +64,8 @@ const tsFilesConfig = {
     rules: {
         '@typescript-eslint/consistent-type-imports': 'error',
         '@typescript-eslint/no-dynamic-delete': 'off',
-        '@typescript-eslint/no-non-null-assertion': 'off'
+        '@typescript-eslint/no-non-null-assertion': 'off',
+        '@typescript-eslint/prefer-for-of': 'off'
     }
 };
 


### PR DESCRIPTION
Disables `@typescript-eslint/prefer-for-of` in the shared TypeScript config so indexed loops remain valid without local overrides.

Manual smoke test:
1. Open a TypeScript consumer project using `@playcanvas/eslint-config/typescript`.
2. Inspect a file with an indexed `for` loop over an array.
3. Expected: the editor ESLint integration reports no `prefer-for-of` diagnostic for that loop.