### PR TITLE
feat: ban unsafe type escape hatches

### DIFF
--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -3,7 +3,7 @@
 // ONLY the declared peers, then import every entry point. fails if any runtime
 // plugin is missing from `dependencies` — the failure publint cannot detect,
 // and the reason v3.0.0-beta.0 was unusable.
-import { execSync } from 'node:child_process';
+import { execSync, spawnSync } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -32,5 +32,25 @@ for (const entry of entries) {
     run(`node --input-type=module -e "await import('${spec}'); console.log('  loaded ${spec}')"`, dir);
 }
 
+writeFileSync(
+    join(dir, 'eslint.config.mjs'),
+    "import typescript from '@playcanvas/eslint-config/typescript';\nexport default typescript;\n"
+);
+writeFileSync(
+    join(dir, 'bad.ts'),
+    'const data = {} as AnyRecord;\nconst cast = data as unknown as Record<string, string>;\nvoid cast;\n'
+);
+
+const lint = spawnSync('npx', ['eslint', 'bad.ts'], { cwd: dir, encoding: 'utf8' });
+const output = `${lint.stdout}\n${lint.stderr}`;
+if (
+    lint.status === 0 ||
+    !output.includes('Use a narrower type instead of AnyRecord') ||
+    !output.includes('Do not cast through unknown to bypass type checking')
+) {
+    console.error(output);
+    process.exit(1);
+}
+
 rmSync(dir, { recursive: true, force: true });
-console.log('test: all entry points load with only declared dependencies');
+console.log('test: entry points load and TypeScript restrictions apply');

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -3,7 +3,7 @@
 // ONLY the declared peers, then import every entry point. fails if any runtime
 // plugin is missing from `dependencies` — the failure publint cannot detect,
 // and the reason v3.0.0-beta.0 was unusable.
-import { execSync, spawnSync } from 'node:child_process';
+import { execSync } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -32,25 +32,5 @@ for (const entry of entries) {
     run(`node --input-type=module -e "await import('${spec}'); console.log('  loaded ${spec}')"`, dir);
 }
 
-writeFileSync(
-    join(dir, 'eslint.config.mjs'),
-    "import typescript from '@playcanvas/eslint-config/typescript';\nexport default typescript;\n"
-);
-writeFileSync(
-    join(dir, 'bad.ts'),
-    'const data = {} as AnyRecord;\nconst cast = data as unknown as Record<string, string>;\nvoid cast;\n'
-);
-
-const lint = spawnSync('npx', ['eslint', 'bad.ts'], { cwd: dir, encoding: 'utf8' });
-const output = `${lint.stdout}\n${lint.stderr}`;
-if (
-    lint.status === 0 ||
-    !output.includes('Use a narrower type instead of AnyRecord') ||
-    !output.includes('Do not cast through unknown to bypass type checking')
-) {
-    console.error(output);
-    process.exit(1);
-}
-
 rmSync(dir, { recursive: true, force: true });
-console.log('test: entry points load and TypeScript restrictions apply');
+console.log('test: all entry points load with only declared dependencies');

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -65,7 +65,18 @@ const tsFilesConfig = {
         '@typescript-eslint/consistent-type-imports': 'error',
         '@typescript-eslint/no-dynamic-delete': 'off',
         '@typescript-eslint/no-non-null-assertion': 'off',
-        '@typescript-eslint/prefer-for-of': 'off'
+        '@typescript-eslint/prefer-for-of': 'off',
+        'no-restricted-syntax': [
+            'error',
+            {
+                selector: 'TSTypeReference[typeName.type="Identifier"][typeName.name="AnyRecord"]',
+                message: 'Use a narrower type instead of AnyRecord'
+            },
+            {
+                selector: 'TSAsExpression > TSAsExpression[typeAnnotation.type="TSUnknownKeyword"]',
+                message: 'Do not cast through unknown to bypass type checking'
+            }
+        ]
     }
 };
 


### PR DESCRIPTION
Adds shared TypeScript config restrictions for two unsafe typing bypasses:

- `AnyRecord` type references now report a lint error.
- Double-casts through `unknown`, like `value as unknown as Type`, now report a lint error.

Manual smoke test:
1. Open a TypeScript consumer project using `@playcanvas/eslint-config/typescript`.
2. Add `const a = {} as AnyRecord;` and `const b = a as unknown as Record<string, string>;`.
3. Expected: the editor ESLint integration reports both unsafe type escape hatch diagnostics.